### PR TITLE
#31

### DIFF
--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -207,7 +207,7 @@ func resourceAlertCreate(d *schema.ResourceData, m interface{}) error {
 	if g {
 		createAlert.GroupByAggregationFields = d.Get(alert_group_by_aggregation_fields).([]interface{})
 	} else {
-		createAlert.GroupByAggregationFields = nil
+		createAlert.GroupByAggregationFields = make([]interface{}, 0)
 	}
 
 	jsonBytes, err := json.Marshal(createAlert)

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -207,7 +207,7 @@ func resourceAlertCreate(d *schema.ResourceData, m interface{}) error {
 	if g {
 		createAlert.GroupByAggregationFields = d.Get(alert_group_by_aggregation_fields).([]interface{})
 	} else {
-		createAlert.GroupByAggregationFields = []
+		createAlert.GroupByAggregationFields = nil
 	}
 
 	jsonBytes, err := json.Marshal(createAlert)

--- a/logzio/resource_alert.go
+++ b/logzio/resource_alert.go
@@ -207,7 +207,7 @@ func resourceAlertCreate(d *schema.ResourceData, m interface{}) error {
 	if g {
 		createAlert.GroupByAggregationFields = d.Get(alert_group_by_aggregation_fields).([]interface{})
 	} else {
-		createAlert.GroupByAggregationFields = nil
+		createAlert.GroupByAggregationFields = []
 	}
 
 	jsonBytes, err := json.Marshal(createAlert)


### PR DESCRIPTION
We noticed the alerts created via API have “groupByAggregationFields”: null, while it should be “groupByAggregationFields”: [], this causes the triggered alert link (the one that says 'view in kibana' to fail (you get an error from logz 'unable to fetch logs').